### PR TITLE
Add support for different reply types (in-channel, in-thread, ephemeral)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,8 @@ karmabot is a Slack bot that listens for and performs karma operations (aka upvo
 | `-reactjis.upvote string`   | no        | **may be passed multiple times** a list of reactjis to use for upvotes. for emojis with aliases, use the first name that is shown in the emoji popup | `+1`, `thumbsup`, `thumbsup_all` | `KB_REACTJIS_UPVOTE`   |
 | `-reactjis.downvote string` | no        | **may be passed multiple times** a list of reactjis to use for downvotes. for emojis with aliases, use the first name that is shown in the emoji popup | `-1`, `thumbsdown`               | `KB_REACTJIS_DOWNVOTE` |
 | `-alias string`             | no        | **may be passed multiple times** alias different users to one user. syntax: `-alias main++alias1++alias2++...++aliasN` |                                  | `KB_ALIAS`             |
-| `-selfkarma bool`           | yes       | allow users to add/remove karma to themselves                | `true`                           | `KB_SELFKARMA`         |
+| `-selfkarma bool`           | no       | allow users to add/remove karma to themselves                | `true`                           | `KB_SELFKARMA`         |
+| `-replytype string`           | no       | whether to reply in channel (`message`) or in a new thread under the user's message (`thread`)                | `message`                           | `KB_REPLYTYPE`         |
 
 In addition, see the table below for the options related to the web UI.
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ karmabot is a Slack bot that listens for and performs karma operations (aka upvo
 | `-reactjis.downvote string` | no        | **may be passed multiple times** a list of reactjis to use for downvotes. for emojis with aliases, use the first name that is shown in the emoji popup | `-1`, `thumbsdown`               | `KB_REACTJIS_DOWNVOTE` |
 | `-alias string`             | no        | **may be passed multiple times** alias different users to one user. syntax: `-alias main++alias1++alias2++...++aliasN` |                                  | `KB_ALIAS`             |
 | `-selfkarma bool`           | no       | allow users to add/remove karma to themselves                | `true`                           | `KB_SELFKARMA`         |
-| `-replytype string`           | no       | whether to reply in channel (`message`) or in a new thread under the user's message (`thread`)                | `message`                           | `KB_REPLYTYPE`         |
+| `-replytype string`           | no       | whether to reply in channel (`message`), in a new thread under the user's message (`thread`), or only visible to the acting user (`ephemeral`)                | `message`                           | `KB_REPLYTYPE`         |
 
 In addition, see the table below for the options related to the web UI.
 

--- a/chat_service_test.go
+++ b/chat_service_test.go
@@ -1,6 +1,8 @@
 package karmabot
 
-import "github.com/nlopes/slack"
+import (
+	"github.com/nlopes/slack"
+)
 
 type TestChatService struct {
 	IncomingEvents chan slack.RTMEvent
@@ -43,5 +45,15 @@ func (t *TestChatService) SendMessage(m *slack.OutgoingMessage) {
 }
 
 func (t *TestChatService) PostEphemeral(channelID, userID string, options ...slack.MsgOption) (string, error) {
-	panic("Unimplemented")
+	// run options
+	_, values, _ := slack.UnsafeApplyMsgOptions("", "", options...)
+	message := values.Get("text")
+
+	t.SendMessage(
+		t.NewOutgoingMessage(
+			message, "user",
+		),
+	)
+
+	return "", nil
 }

--- a/chat_service_test.go
+++ b/chat_service_test.go
@@ -41,3 +41,7 @@ func (t *TestChatService) NewOutgoingMessage(text string, channel string, option
 func (t *TestChatService) SendMessage(m *slack.OutgoingMessage) {
 	t.SentMessages = append(t.SentMessages, m)
 }
+
+func (t *TestChatService) PostEphemeral(channelID, userID string, options ...slack.MsgOption) (string, error) {
+	panic("Unimplemented")
+}

--- a/cmd/karmabot/main.go
+++ b/cmd/karmabot/main.go
@@ -33,6 +33,7 @@ var (
 	downvotereactji  = make(karmabot.StringList, 0)
 	aliases          = make(karmabot.StringList, 0)
 	selfkarma        = flag.Bool("selfkarma", true, "allow users to add/remove karma to themselves")
+	replytype        = flag.String("replytype", "message", "how to reply to commands (message, thread)")
 )
 
 func main() {
@@ -145,6 +146,7 @@ func main() {
 		Motivate:         *motivate,
 		Aliases:          aliasMap,
 		SelfKarma:        *selfkarma,
+		ReplyType:        *replytype,
 	})
 
 	bot.Listen()

--- a/main_test.go
+++ b/main_test.go
@@ -89,7 +89,7 @@ func TestHandleSlackEvent(t *testing.T) {
 				ItemUser: "onehundred_points",
 				Reaction: "+1",
 			},
-			ExpectMessage:    "onehundred_points == 101 (+1 for adding a :+1: reactji)",
+			ExpectMessage:    "onehundred_points == 101 (+1 for user added a :+1: reactji)",
 			ShouldHavePoints: 101,
 		},
 		{
@@ -100,7 +100,7 @@ func TestHandleSlackEvent(t *testing.T) {
 				ItemUser: "onehundred_points",
 				Reaction: "-1",
 			},
-			ExpectMessage:    "onehundred_points == 99 (-1 for adding a :-1: reactji)",
+			ExpectMessage:    "onehundred_points == 99 (-1 for user added a :-1: reactji)",
 			ShouldHavePoints: 99,
 		},
 		{
@@ -133,7 +133,7 @@ func TestHandleSlackEvent(t *testing.T) {
 				ItemUser: "onehundred_points",
 				Reaction: "+1",
 			},
-			ExpectMessage:    "onehundred_points == 99 (-1 for removing a :+1: reactji)",
+			ExpectMessage:    "onehundred_points == 99 (-1 for user removed a :+1: reactji)",
 			ShouldHavePoints: 99,
 		},
 		{
@@ -144,7 +144,7 @@ func TestHandleSlackEvent(t *testing.T) {
 				ItemUser: "onehundred_points",
 				Reaction: "-1",
 			},
-			ExpectMessage:    "onehundred_points == 101 (+1 for removing a :-1: reactji)",
+			ExpectMessage:    "onehundred_points == 101 (+1 for user removed a :-1: reactji)",
 			ShouldHavePoints: 101,
 		},
 		{


### PR DESCRIPTION
1. Add the option to configure karmabot to reply to karma operations:
    * in channel or in thread depending on where the user posted the message (old behavior, reply type: `message`)
    * always in a thread (reply type: `thread`)
    * as an ephemeral message visible only to the user (reply type: `ephemeral`)
2. Acknowledge reactji operations using ephemeral messages instead of annoying DMs

Closes #50.